### PR TITLE
update rpmfusion repositories install mechanism

### DIFF
--- a/functions/repos
+++ b/functions/repos
@@ -25,7 +25,7 @@ case $REPLY in
         # Add repository
         echo 'Adding RPM Fusion to repositories...'
         show_info 'Requires root privileges:'
-        su -c 'dnf install http://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm http://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm'
+        su -c 'rpm -Uvh http://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm http://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm'
         show_success 'Done.'
         # Update system
         echo 'Performing system update...'

--- a/functions/repos
+++ b/functions/repos
@@ -25,7 +25,7 @@ case $REPLY in
         # Add repository
         echo 'Adding RPM Fusion to repositories...'
         show_info 'Requires root privileges:'
-        su -c 'rpm -Uvh http://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-stable.noarch.rpm http://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-stable.noarch.rpm'
+        su -c 'dnf install http://download1.rpmfusion.org/free/fedora/rpmfusion-free-release-$(rpm -E %fedora).noarch.rpm http://download1.rpmfusion.org/nonfree/fedora/rpmfusion-nonfree-release-$(rpm -E %fedora).noarch.rpm'
         show_success 'Done.'
         # Update system
         echo 'Performing system update...'


### PR DESCRIPTION
rpmfusion-*-release-stable.noarch.rpm corresponds to version 22 and is actually same as rpmfusion-*-release-stable.22.rpm.
Edits are as per suggested configuration at http://rpmfusion.org/Configuration/ and installs rpmfusion-free-release-stable.<VERSION>.rpm rpmfusion-nonfree-release-stable.<VERSION>.rpm.
