### PR TITLE
update ST3 download mechanism

### DIFF
--- a/functions/sublime3
+++ b/functions/sublime3
@@ -11,9 +11,11 @@ cd $HOME/Downloads
 echo 'Downloading Sublime Text 3 (build 3083)...'
 # Download tarball that matches system architecture
 if [ $(uname -i) = 'i386' ]; then
-    curl -O http://c758482.r82.cf2.rackcdn.com/sublime_text_3_build_3083.tar.bz2
+    curl -O "http://c758482.r82.cf2.rackcdn.com/$(wget http://www.sublimetext.com/3 -O - | grep -Po sublime_t
+ext_3_build_[0-9]{4}_x32.tar.bz2)"
 elif [ $(uname -i) = 'x86_64' ]; then
-    curl -O http://c758482.r82.cf2.rackcdn.com/sublime_text_3_build_3083_x64.tar.bz2
+    curl -O "http://c758482.r82.cf2.rackcdn.com/$(wget http://www.sublimetext.com/3 -O - | grep -Po sublime_t
+ext_3_build_[0-9]{4}_x64.tar.bz2)"
 fi
 # Extract Tarball
 cd $HOME/Downloads


### PR DESCRIPTION
- "http://c758482.r82.cf2.rackcdn.com/sublime_text_3_build_3083.tar.bz2" results in a 404.
- new download mechanism always gets the latest build.
